### PR TITLE
Initiating Nautobot jobs, next-2.0 rebase

### DIFF
--- a/changes/224.added
+++ b/changes/224.added
@@ -1,3 +1,0 @@
-Add init_job Nautobot subcommand, which starts a Nautobot job by job name.
-Add get_jobs Nautobot subcommand, which gets all Nautobot jobs.
-Add filter_jobs Nautobot subcommand, which gets filtered set of Nautobot jobs.

--- a/changes/224.added
+++ b/changes/224.added
@@ -1,0 +1,3 @@
+Add init_job Nautobot subcommand, which starts a Nautobot job by job name.
+Add get_jobs Nautobot subcommand, which gets all Nautobot jobs.
+Add filter_jobs Nautobot subcommand, which gets filtered set of Nautobot jobs.

--- a/changes/270.added
+++ b/changes/270.added
@@ -1,0 +1,4 @@
+Add init_jobs Nautobot subcommand.
+Add kwargs input to init_jobs as JSON-string to init_jobs.
+Add get_jobs Nautobot subcommand, which returns all Nautobot jobs viewable to user.
+Add filter_jobs Nautobot subcommand, which returns filtered set of Nautobot jobs viewable to user.

--- a/changes/270.added
+++ b/changes/270.added
@@ -1,4 +1,4 @@
-Add init_job Nautobot subcommand, which initiates a job with kwargs or a job requiring no manual form input.
-Add init_job_form Nautobot subcommand, which presents job's form widgets to the user.
+Add run_job Nautobot subcommand, which initiates a job with kwargs or a job requiring no manual form input.
+Add run_job_form Nautobot subcommand, which presents job's form widgets to the user.
 Add get_jobs Nautobot subcommand, which returns all Nautobot jobs viewable to user.
 Add filter_jobs Nautobot subcommand, which returns filtered set of Nautobot jobs viewable to user.

--- a/changes/270.added
+++ b/changes/270.added
@@ -1,4 +1,4 @@
-Add init_jobs Nautobot subcommand.
-Add kwargs input to init_jobs as JSON-string to init_jobs.
+Add init_job Nautobot subcommand, which initiates a job with kwargs or a job requiring no manual form input.
+Add init_job_form Nautobot subcommand, which presents job's form widgets to the user.
 Add get_jobs Nautobot subcommand, which returns all Nautobot jobs viewable to user.
 Add filter_jobs Nautobot subcommand, which returns filtered set of Nautobot jobs viewable to user.

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1122,15 +1122,14 @@ def get_jobs(dispatcher, kwargs: str = ""):
     return CommandStatusChoices.STATUS_SUCCEEDED
 
 
-# pylint: disable=too-many-locals
 @subcommand_of("nautobot")
-def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""):
+def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""):  # pylint: disable=too-many-locals
     """Initiate a job in Nautobot by job name.
 
     Args:
+        *args (tuple): Dispatcher form will pass job args as tuple.
         job_name (str): Name of Nautobot job to run.
         json_string_kwargs (str): JSON-string dictionary for input keyword arguments for job run.
-        *args (tuple): Dispatcher form will pass job args as tuple.
     """
     # Prompt the user to pick a job if they did not specify one
     if not job_name:

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -3,7 +3,6 @@
 import json
 
 
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db.models import Count
 from django.contrib.contenttypes.models import ContentType
@@ -1137,14 +1136,6 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
     if json_args.get("profile") and json_args["profile"] is True:
         profile = True
 
-    # Get instance of the user who will run the job
-    user = get_user_model()
-    try:
-        user_instance = user.objects.get(username=dispatcher.user)
-    except user.DoesNotExist:  # Unsure if we need to check this case?
-        dispatcher.send_error(f"User {dispatcher.user} not found")
-        return (CommandStatusChoices.STATUS_FAILED, f'User "{dispatcher.user}" was not found')
-
     # Get the job model instance using job name
     try:
         job_model = Job.objects.restrict(dispatcher.user, "view").get(name=job_name)
@@ -1161,7 +1152,7 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
     # TODO: Check if json_args keys are valid for this job model
     job_result = JobResult.execute_job(
         job_model=job_model,
-        user=user_instance,
+        user=dispatch.user,
         profile=profile,
         **json_args,
     )

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1056,6 +1056,7 @@ def filter_jobs(
     dispatcher, job_filters: str = ""
 ):  # We can use a Literal["enabled", "installed", "runnable"] here instead
     """Get a filtered list of jobs from Nautobot that the request user have view permissions for.
+    
     Args:
         job_filters (str): Filter job results by literals in a comma-separated string.
                            Available filters are: enabled, installed.
@@ -1098,7 +1099,7 @@ def get_jobs(dispatcher, kwargs: str = ""):
     try:
         if kwargs:
             json_args = json.loads(kwargs)
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         dispatcher.send_error(f"Invalid JSON-string, cannot decode: {kwargs}")
         return (CommandStatusChoices.STATUS_FAILED, f"Invalid JSON-string, cannot decode: {kwargs}")
 
@@ -1134,12 +1135,12 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
     try:
         if kwargs:
             json_args = json.loads(kwargs)
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         dispatcher.send_error(f"Invalid JSON-string, cannot decode: {kwargs}")
         return (CommandStatusChoices.STATUS_FAILED, f"Invalid JSON-string, cannot decode: {kwargs}")
 
     profile = False
-    if json_args.get("profile") and json_args["profile"] == True:
+    if json_args.get("profile") and json_args["profile"] is True:
         profile = True
 
     # Get instance of the user who will run the job

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1120,6 +1120,7 @@ def get_jobs(dispatcher, kwargs: str = ""):
     return CommandStatusChoices.STATUS_SUCCEEDED
 
 
+# pylint: disable=too-many-locals
 @subcommand_of("nautobot")
 def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""):
     """Initiate a job in Nautobot by job name.

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1122,12 +1122,12 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
             json_args = json.loads(kwargs)
     except json.JSONDecodeError as exc:
         dispatcher.send_error(f"Invalid JSON-string, cannot decode: {kwargs}")
-        return (CommandStatusChoices.STATUS_FAILED, f'Invalid JSON-string, cannot decode: {kwargs}')
-    
+        return (CommandStatusChoices.STATUS_FAILED, f"Invalid JSON-string, cannot decode: {kwargs}")
+
     profile = False
     if json_args.get("profile") and json_args["profile"] == True:
         profile = True
-    
+
     # Get instance of the user who will run the job
     user = get_user_model()
     try:

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1058,11 +1058,11 @@ def filter_jobs(
     """Get a filtered list of jobs from Nautobot that the request user have view permissions for.
     Args:
         job_filters (str): Filter job results by literals in a comma-separated string.
-                           Available filters are: enabled, installed or runnable.
+                           Available filters are: enabled, installed.
     """
     # Check for filters in user supplied input
     job_filters_list = [item.strip() for item in job_filters.split(",")] if isinstance(job_filters, str) else ""
-    filters = ["enabled", "installed", "runnable"]
+    filters = ["enabled", "installed"]  # Runnable is not valid
     if any([key in job_filters for key in filters]):
         filter_args = {key: True for key in filters if key in job_filters_list}
         jobs = Job.objects.restrict(dispatcher.user, "view").filter(

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1329,7 +1329,7 @@ def init_job_form(dispatcher, job_name: str = ""):
             )
 
         elif field_type == "number":
-            # TODO: Can we enforce numeric-character mask for widget input?
+            # TODO: Can we enforce numeric-character mask for widget input without JavaScript?
             default_value = field.initial
             form_item_dialogs.append(
                 {

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1276,7 +1276,7 @@ def init_job_form(dispatcher, job_name: str = ""):
     for field_name, field in form_items.items():
         try:
             field_type = field.widget.input_type
-        except:
+        except AttributeError:
             # Some widgets (eg: textarea) do have the `input_type` attribute
             field_type = field.widget.template_name.split("/")[-1].split(".")[0]
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1056,7 +1056,7 @@ def filter_jobs(
     dispatcher, job_filters: str = ""
 ):  # We can use a Literal["enabled", "installed", "runnable"] here instead
     """Get a filtered list of jobs from Nautobot that the request user have view permissions for.
-    
+
     Args:
         job_filters (str): Filter job results by literals in a comma-separated string.
                            Available filters are: enabled, installed.

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1220,7 +1220,7 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
     )
     blocks = [
         dispatcher.markdown_block(
-            f"The requested job {job_class_path} was initiated! [`click here`]({job_url}) to open the job."
+            f"The requested job {job_model.class_path} was initiated! [`click here`]({job_url}) to open the job."
         ),
     ]
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1171,9 +1171,7 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
 
     # Basic logic check with what we know, we should expect init-job-form vs init-job to parse the same base fields
     if len(form_fields) != len(args):
-        dispatcher.send_error(
-            "The form class fields and the passed init-jobs args do not match."
-        )
+        dispatcher.send_error("The form class fields and the passed init-jobs args do not match.")
         return (
             CommandStatusChoices.STATUS_FAILED,
             "The form class fields and the passed init-jobs args do not match.",
@@ -1239,7 +1237,7 @@ def init_job_form(dispatcher, job_name: str = ""):
     except Job.DoesNotExist:
         blocks = [
             dispatcher.markdown_block(
-                f"Job {job_name} does not exist or {dispatcher.user} does not have permissions to run job." # pylint: disable=line-too-long
+                f"Job {job_name} does not exist or {dispatcher.user} does not have permissions to run job."  # pylint: disable=line-too-long
             ),
         ]
         dispatcher.send_blocks(blocks)

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1123,7 +1123,7 @@ def get_jobs(dispatcher, kwargs: str = ""):
 
 
 @subcommand_of("nautobot")
-def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""):  # pylint: disable=too-many-locals
+def run_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""):  # pylint: disable=too-many-locals
     """Initiate a job in Nautobot by job name.
 
     Args:
@@ -1133,7 +1133,7 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
     """
     # Prompt the user to pick a job if they did not specify one
     if not job_name:
-        return prompt_for_job(dispatcher, "nautobot init-job")
+        return prompt_for_job(dispatcher, "nautobot run-job")
 
     if args:
         json_string_kwargs = "{}"
@@ -1171,12 +1171,12 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
             continue
         form_fields.append(f"{field_name}")
 
-    # Basic logic check with what we know, we should expect init-job-form vs init-job to parse the same base fields
+    # Basic logic check with what we know, we should expect run-job-form vs run-job to parse the same base fields
     if len(form_fields) != len(args):
-        dispatcher.send_error("The form class fields and the passed init-jobs args do not match.")
+        dispatcher.send_error("The form class fields and the passed run-job args do not match.")
         return (
             CommandStatusChoices.STATUS_FAILED,
-            "The form class fields and the passed init-jobs args do not match.",
+            "The form class fields and the passed run-job args do not match.",
         )
 
     form_item_kwargs = {}
@@ -1234,7 +1234,7 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
 
 
 @subcommand_of("nautobot")
-def init_job_form(dispatcher, job_name: str = ""):
+def run_job_form(dispatcher, job_name: str = ""):
     """Send job form as a multi-input dialog. On form submit it initiates the job with the form arguments.
 
     Args:
@@ -1242,7 +1242,7 @@ def init_job_form(dispatcher, job_name: str = ""):
     """
     # Prompt the user to pick a job if they did not specify one
     if not job_name:
-        return prompt_for_job(dispatcher, "nautobot init-job-form")
+        return prompt_for_job(dispatcher, "nautobot run-job-form")
 
     # Get jobs available to user
     try:
@@ -1373,7 +1373,7 @@ def init_job_form(dispatcher, job_name: str = ""):
     # TODO: BUG: Single inputs will present but not submit properly with multi_input_dialog
     dispatcher.multi_input_dialog(
         command="nautobot",
-        sub_command=f"init-job {job_name} {{}}",
+        sub_command=f"run-job {job_name} {{}}",
         dialog_title=f"job {job_name} form input",
         dialog_list=form_item_dialogs,
     )

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1059,7 +1059,7 @@ def filter_jobs(dispatcher, job_filters: str = ""):  # We can use a Literal["ena
     # Check for filters in user supplied input
     job_filters_list = [item.strip() for item in job_filters.split(",")] if isinstance(job_filters, str) else ""
     filters = ["enabled", "installed"]
-    if any([key in job_filters for key in filters]):
+    if any(key in job_filters for key in filters):
         filter_args = {key: True for key in filters if key in job_filters_list}
         jobs = Job.objects.restrict(dispatcher.user, "view").filter(**filter_args)  # enabled=True, installed=True
     else:

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1216,8 +1216,8 @@ def run_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = "")
         job_result.refresh_from_db()
 
     if job_result and job_result.status == "FAILURE":
-        dispatcher.send_error(f"The requested job {job_name} failed to initiate. Result: {job_result.result}")
-        return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" failed to initiate. Result: {job_result.result}')
+        dispatcher.send_error(f"The requested job {job_name} was initiated but failed. Result: {job_result.result}")
+        return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" was initiated but failed. Result: {job_result.result}')  # pylint: disable=line-too-long
 
     job_url = (
         f"{dispatcher.context['request_scheme']}://{dispatcher.context['request_host']}{job_result.get_absolute_url()}"

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1206,7 +1206,12 @@ def init_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = ""
     )
 
     # Wait on the job to finish
+    max_wait_iterations = 60
     while job_result.status not in JobResultStatusChoices.READY_STATES:
+        max_wait_iterations -= 1
+        if not max_wait_iterations:
+            dispatcher.send_error(f"The requested job {job_name} failed to reach ready state.")
+            return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" failed to reach ready state.')
         time.sleep(1)
         job_result.refresh_from_db()
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1152,7 +1152,7 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
     # TODO: Check if json_args keys are valid for this job model
     job_result = JobResult.execute_job(
         job_model=job_model,
-        user=dispatch.user,
+        user=dispatcher.user,
         profile=profile,
         **json_args,
     )

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1217,7 +1217,10 @@ def run_job(dispatcher, *args, job_name: str = "", json_string_kwargs: str = "")
 
     if job_result and job_result.status == "FAILURE":
         dispatcher.send_error(f"The requested job {job_name} was initiated but failed. Result: {job_result.result}")
-        return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" was initiated but failed. Result: {job_result.result}')  # pylint: disable=line-too-long
+        return (
+            CommandStatusChoices.STATUS_FAILED,
+            f'Job "{job_name}" was initiated but failed. Result: {job_result.result}',
+        )  # pylint: disable=line-too-long
 
     job_url = (
         f"{dispatcher.context['request_scheme']}://{dispatcher.context['request_host']}{job_result.get_absolute_url()}"

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1170,9 +1170,14 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
         profile=profile,
         **json_args,
     )
+    
+    if job_result and job_result.status == "FAILURE":
+        dispatcher.send_error(f"The requested job {job_name} failed to initiate. Result: {job_result.result}")
+        return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" failed to initiate. Result: {job_result.result}')
 
+    # TODO: need base-domain, this yields: /extras/job-results/<job_id>/
     blocks = [
-        dispatcher.markdown_block(f"The requested job {job_class_path} was initiated!"),
+        dispatcher.markdown_block(f"The requested job {job_class_path} was initiated! [`click here`]({job_result.get_absolute_url()}) to open the job."),
     ]
 
     dispatcher.send_blocks(blocks)

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1390,11 +1390,7 @@ def init_job_form(dispatcher, job_name: str = ""):
     #    ),
     # ]
 
-    blocks = [
-        dispatcher.markdown_block("demo ran, fin"),
-    ]
-
-    dispatcher.send_blocks(blocks)
+    # dispatcher.send_blocks(blocks)
 
     return CommandStatusChoices.STATUS_SUCCEEDED
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1,6 +1,5 @@
 """Worker functions for interacting with Nautobot."""
 
-import uuid
 import json
 
 
@@ -15,7 +14,6 @@ from nautobot.circuits.models import Circuit, CircuitType, Provider, CircuitTerm
 from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer, Rack, Cable
 from nautobot.ipam.models import VLAN, Prefix, VLANGroup
 from nautobot.tenancy.models import Tenant
-from nautobot.extras.context_managers import web_request_context
 from nautobot.extras.models import Job, JobResult, Role, Status
 
 from nautobot_chatops.choices import CommandStatusChoices
@@ -1177,9 +1175,10 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
         return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" failed to initiate. Result: {job_result.result}')
 
     # TODO: need base-domain, this yields: /extras/job-results/<job_id>/
+    job_url = job_result.get_absolute_url()
     blocks = [
         dispatcher.markdown_block(
-            f"The requested job {job_class_path} was initiated! [`click here`]({job_result.get_absolute_url()}) to open the job."
+            f"The requested job {job_class_path} was initiated! [`click here`]({job_url}) to open the job."
         ),
     ]
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1050,9 +1050,7 @@ def get_circuit_providers(dispatcher, *args):
 
 
 @subcommand_of("nautobot")
-def filter_jobs(
-    dispatcher, job_filters: str = ""
-):  # We can use a Literal["enabled", "installed", "runnable"] here instead
+def filter_jobs(dispatcher, job_filters: str = ""):  # We can use a Literal["enabled", "installed"] here instead
     """Get a filtered list of jobs from Nautobot that the request user have view permissions for.
 
     Args:
@@ -1061,12 +1059,10 @@ def filter_jobs(
     """
     # Check for filters in user supplied input
     job_filters_list = [item.strip() for item in job_filters.split(",")] if isinstance(job_filters, str) else ""
-    filters = ["enabled", "installed"]  # Runnable is not valid
+    filters = ["enabled", "installed"]
     if any([key in job_filters for key in filters]):
         filter_args = {key: True for key in filters if key in job_filters_list}
-        jobs = Job.objects.restrict(dispatcher.user, "view").filter(
-            **filter_args
-        )  # enabled=True, installed=True, runnable=True
+        jobs = Job.objects.restrict(dispatcher.user, "view").filter(**filter_args)  # enabled=True, installed=True
     else:
         jobs = Job.objects.restrict(dispatcher.user, "view").all()
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -1170,14 +1170,16 @@ def init_job(dispatcher, job_name: str, kwargs: str = ""):
         profile=profile,
         **json_args,
     )
-    
+
     if job_result and job_result.status == "FAILURE":
         dispatcher.send_error(f"The requested job {job_name} failed to initiate. Result: {job_result.result}")
         return (CommandStatusChoices.STATUS_FAILED, f'Job "{job_name}" failed to initiate. Result: {job_result.result}')
 
     # TODO: need base-domain, this yields: /extras/job-results/<job_id>/
     blocks = [
-        dispatcher.markdown_block(f"The requested job {job_class_path} was initiated! [`click here`]({job_result.get_absolute_url()}) to open the job."),
+        dispatcher.markdown_block(
+            f"The requested job {job_class_path} was initiated! [`click here`]({job_result.get_absolute_url()}) to open the job."
+        ),
     ]
 
     dispatcher.send_blocks(blocks)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot ChatOps! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #223
# #224 closed in favor of this rebase

## What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Adds the following nautobot subcommands:
- `init_job()` as `init-job`
  - Adds `init_job` subccomand which initiates a Nautobot job by job name
  - Update init_jobs for new pattern, tested and working
  - Adds `kwargs` JSON-string dictionary to init_jobs (untested but looks good)

- `get_jobs()` as `get-jobs`
  - Adds `get_jobs` which returns all Nautobot jobs viewable to user
  - Adds `kwargs` JSON-string list to get_jobs export header items (tested as working)

- `filter_jobs()` as `filter-jobs`
  - Adds `filter_jobs` which returns filtered set of Nautobot jobs viewable to user
    - eg: `/nautobot filter-jobs "enabled"` or `/nautobot filter-jobs "enabled,installed"`
       - this could be changed to JSON-string dictionary/list? eg: `/nautobot filter-jobs '{"enabled": true}'`

## Remaining work
- [ ]  The render markdown for `init_job` should presen thet job form items
  - [x] With `init_job` method we can pass kwargs as JSON-string (untested)
- [ ] Add to documentation

## TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/chatops/en/latest/dev/contributing/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

## Screenshots

### /nautobot init-job
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/ddff3d25-763e-48cb-be3d-f5715c867ed9)

### /nautobot init-jobs for job that is not enabled
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/3e4cea68-41b7-44c8-bd43-7fc1b800adf8)

if there is a failed job, we will return the job_result.result message
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/2c0cafe1-bbbe-4c8f-a2e1-30e38330faed)




### /nautobot get-jobs
by default we will get some head items
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/a75d0cbd-1417-4473-9431-f5603ee95abe)


### /nautobot get-jobs '["id", "name", "installed", "tags"]'
we can specify the header items we want with a JSON formatted list
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/c1d18c3e-1427-459b-bdc8-40396300fc96)
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/4fe6c345-5f0e-4fb7-9bf8-c8fa8b88bcf7)

if there is a bad key, eg: `/nautobot get-jobs '["id", "name", "invalid key demo"]'`
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/78031281-1038-4f64-83c2-93814b3526ac)




### /nautobot filter-jobs "enabled"
![image](https://github.com/nautobot/nautobot-plugin-chatops/assets/114895043/9ae44b7f-6638-40d3-a2b0-8d2bf6505d02)


### Notes
- I was having some GIT troubles rebasing to next-2.0 the exact way I wanted, which is why I opened this PR. The other PR may serve use for any 1.x hold-overs by using the static service account?
- Thanks for the hard work on the user permission mapping @smk4664 , the feature looks solid



