### PR TITLE
Updates for activating docs link.

### DIFF
--- a/changes/319.documentation
+++ b/changes/319.documentation
@@ -1,0 +1,1 @@
+Updated app config settings to point to new url.py path for activating docs link.

--- a/nautobot_chatops/__init__.py
+++ b/nautobot_chatops/__init__.py
@@ -151,6 +151,7 @@ class NautobotChatOpsConfig(NautobotAppConfig):
     }
 
     caching_config = {}
+    docs_view_name = "plugins:nautobot_chatops:docs"
 
     def ready(self):
         """Function invoked after all apps have been loaded."""

--- a/nautobot_chatops/urls.py
+++ b/nautobot_chatops/urls.py
@@ -2,6 +2,8 @@
 import logging
 
 from django.urls import path
+from django.templatetags.static import static
+from django.views.generic import RedirectView
 
 from nautobot.apps.config import get_app_settings_or_config
 from nautobot.extras.views import ObjectChangeLogView, ObjectNotesView
@@ -100,4 +102,5 @@ urlpatterns = [
         kwargs={"model": ChatOpsAccountLink},
     ),
     *grafana_urlpatterns,
+    path("docs/", RedirectView.as_view(url=static("nautobot_chatops/docs/index.html")), name="docs"),
 ]


### PR DESCRIPTION
Fixes #319 

Adds new URL path for the docs link and updates app config appropriately.