### PR TITLE
Fix slack-sdk dependency

### DIFF
--- a/changes/333.dependencies
+++ b/changes/333.dependencies
@@ -1,0 +1,1 @@
+Fixed slack-sdk to version ^3.23.0 for `files_upload_v2`.


### PR DESCRIPTION
Closes: https://github.com/nautobot/nautobot-app-chatops/issues/333

slack-sdk `file_upload_V2` was introduced in https://github.com/slackapi/python-slack-sdk/releases/tag/v3.23.0