### PR TITLE
Remove config file from migrations check

### DIFF
--- a/changes/338.housekeeping
+++ b/changes/338.housekeeping
@@ -1,0 +1,1 @@
+Remove --config option from make-migrations check.

--- a/changes/338.housekeeping
+++ b/changes/338.housekeeping
@@ -1,1 +1,1 @@
-Remove --config option from make-migrations check.
+Fixed `invoke check-migrations`.

--- a/tasks.py
+++ b/tasks.py
@@ -591,7 +591,7 @@ def yamllint(context):
 @task
 def check_migrations(context):
     """Check for missing migrations."""
-    command = "nautobot-server --config=nautobot/core/tests/nautobot_config.py makemigrations --dry-run --check"
+    command = "nautobot-server makemigrations --dry-run --check"
 
     run_command(context, command)
 


### PR DESCRIPTION
We should not be running with the test config file as we want the Chatops plugin loaded.