### PR TITLE
Update .cookiecutter.json

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -14,7 +14,7 @@
         "max_nautobot_version": "2.9999",
         "camel_name": "NautobotChatOpsApp",
         "project_short_description": "Nautobot ChatOps App",
-        "model_class_name": "None",
+        "model_class_name": "CommandLog",
         "open_source_license": "Apache-2.0",
         "docs_base_url": "https://docs.nautobot.com",
         "docs_app_url": "https://docs.nautobot.com/projects/chatops/en/latest",

--- a/changes/339.housekeeping
+++ b/changes/339.housekeeping
@@ -1,0 +1,1 @@
+Change model_class_name in .cookiecutter.json to a valid model.

--- a/changes/339.housekeeping
+++ b/changes/339.housekeeping
@@ -1,1 +1,1 @@
-Change model_class_name in .cookiecutter.json to a valid model.
+Changed model_class_name in .cookiecutter.json to a valid model to help with drift management.


### PR DESCRIPTION
Due to the way that Drift Manager uses the .cookiecutter.json file, we need to change the model_class_name to a valid model in BGP models to help us track drift in files that would be removed if the model_class_name=None.