### PR TITLE
Fixed `grafana_default_timespan`

### DIFF
--- a/changes/438.fixed
+++ b/changes/438.fixed
@@ -1,0 +1,1 @@
+Fixed `grafana_default_timespan` to be 0 if not provided.

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -174,7 +174,7 @@ PLUGINS_CONFIG = {
         "grafana_default_width": 0,
         "grafana_default_height": 0,
         "grafana_default_theme": "dark",
-        "grafana_default_timespan": "0",
+        "grafana_default_timespan": 0,
         "grafana_org_id": 1,
         "grafana_default_tz": "America/Denver",
         # - IPFabric --------------------------

--- a/docs/admin/integrations/grafana.md
+++ b/docs/admin/integrations/grafana.md
@@ -52,7 +52,7 @@ PLUGINS_CONFIG = {
         "grafana_default_width": 0,
         "grafana_default_height": 0,
         "grafana_default_theme": "dark",
-        "grafana_default_timespan": "0",
+        "grafana_default_timespan": 0,
         "grafana_org_id": 1,
         "grafana_default_tz": "America/Denver",
     }
@@ -100,7 +100,7 @@ PLUGINS_CONFIG = {
             "grafana_default_width": 0,
             "grafana_default_height": 0,
             "grafana_default_theme": "dark",
-            "grafana_default_timespan": "0",
+            "grafana_default_timespan": 0,
             "grafana_org_id": 1,
             "grafana_default_tz": "America/Denver",
         }

--- a/nautobot_chatops/__init__.py
+++ b/nautobot_chatops/__init__.py
@@ -91,7 +91,7 @@ class NautobotChatOpsConfig(NautobotAppConfig):
         "grafana_default_width": 0,
         "grafana_default_height": 0,
         "grafana_default_theme": "dark",
-        "grafana_default_timespan": "",
+        "grafana_default_timespan": 0,
         "grafana_org_id": 1,
         "grafana_default_tz": "",
         # - IPFabric -------------------------

--- a/nautobot_chatops/integrations/grafana/grafana.py
+++ b/nautobot_chatops/integrations/grafana/grafana.py
@@ -38,11 +38,13 @@ class GrafanaConfigSettings(BaseModel):  # pylint: disable=too-few-public-method
 
 
 def _get_settings_from_chatops(config: dict) -> GrafanaConfigSettings:
+    # If None or empty string, default to 0
+    default_timespan = config["grafana_default_timespan"] or 0
     try:
         # See: https://docs.pydantic.dev/2.6/api/standard_library_types/#datetimetimedelta
-        default_timespan = int(config["grafana_default_timespan"])
+        default_timespan = int(default_timespan)
     except ValueError:
-        default_timespan = config["grafana_default_timespan"]
+        pass
 
     return GrafanaConfigSettings(
         grafana_url=config["grafana_url"],


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot ChatOps App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #438

## What's Changed

This PR changes the default for `grafana_default_timespan` from an empty string to 0.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
